### PR TITLE
Add mutex to protect node.data

### DIFF
--- a/internal/ruletree/ruletree.go
+++ b/internal/ruletree/ruletree.go
@@ -2,7 +2,6 @@ package ruletree
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -91,11 +90,10 @@ func (rt *RuleTree[T]) Add(urlPattern string, data T) error {
 			node = node.findOrAddChild(nodeKey{kind: nodeKindExactMatch, token: token})
 		}
 	}
-	if node == nil {
-		log.Printf("failed to add rule %q: no node found", urlPattern)
-		return fmt.Errorf("no node found")
-	}
+
+	node.dataMu.Lock()
 	node.data = append(node.data, data)
+	node.dataMu.Unlock()
 
 	return nil
 }

--- a/internal/ruletree/ruletree.go
+++ b/internal/ruletree/ruletree.go
@@ -1,6 +1,7 @@
 package ruletree
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,10 +14,10 @@ type Data interface {
 	ParseModifiers(modifiers string) error
 }
 
-// RuleTree is a trie-based filter that is capable of parsing
+// RuleTree is a trie-based matcher that is capable of parsing
 // Adblock-style and hosts rules and matching URLs against them.
 //
-// The filter is safe for concurrent use.
+// It is safe for concurrent use.
 type RuleTree[T Data] struct {
 	// root is the root node of the trie that stores the rules.
 	root node[T]
@@ -64,7 +65,7 @@ func (rt *RuleTree[T]) Add(urlPattern string, data T) error {
 		tokens = []string{}
 		modifiers = match[1]
 	} else {
-		return fmt.Errorf("unknown rule format")
+		return errors.New("unknown rule format")
 	}
 
 	if modifiers != "" {


### PR DESCRIPTION
### What does this PR do?
Fixes a phantom bug triggered in the rare case where `node.data` gets updated concurrently by multiple writers. Clarifies some related documentation.

### How did you verify your code works?


### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
