### PR TITLE
fix: update Hungarian filter list URL in default config

### DIFF
--- a/internal/cfg/default-config.json
+++ b/internal/cfg/default-config.json
@@ -124,7 +124,7 @@
         "type": "regional"
       },
       {
-        "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter.txt",
+        "url": "https://filters.hufilter.hu/hufilter-adguard.txt",
         "name": "🇭🇺HU: hufilter",
         "enabled": false,
         "type": "regional"

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -49,6 +49,10 @@ var migrations = map[string]func(c *Config) error{
 				c.Filter.FilterLists[i].URL = "https://easylist.to/easylist/easylist.txt"
 				log.Printf("v0.7.0 migration: updating EasyList's URL")
 			}
+			if list.URL == "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter.txt" {
+				c.Filter.FilterLists[i].URL = "https://filters.hufilter.hu/hufilter-adguard.txt"
+				log.Printf("v0.7.0 migration: updating Hungarian filter list's URL")
+			}
 		}
 
 		if err := c.Save(); err != nil {

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -49,10 +49,6 @@ var migrations = map[string]func(c *Config) error{
 				c.Filter.FilterLists[i].URL = "https://easylist.to/easylist/easylist.txt"
 				log.Printf("v0.7.0 migration: updating EasyList's URL")
 			}
-			if list.URL == "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter.txt" {
-				c.Filter.FilterLists[i].URL = "https://filters.hufilter.hu/hufilter-adguard.txt"
-				log.Printf("v0.7.0 migration: updating Hungarian filter list's URL")
-			}
 		}
 
 		if err := c.Save(); err != nil {
@@ -84,6 +80,18 @@ var migrations = map[string]func(c *Config) error{
 			}
 		}
 
+		return nil
+	},
+	"v0.10.0": func(c *Config) error {
+		for i, list := range c.Filter.FilterLists {
+			if list.URL == "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter.txt" {
+				c.Filter.FilterLists[i].URL = "https://filters.hufilter.hu/hufilter-adguard.txt"
+				log.Printf("v0.10.0 migration: updating Hungarian filter list's URL")
+			}
+		}
+		if err := c.Save(); err != nil {
+			return fmt.Errorf("save config: %v", err)
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
### What does this PR do?

<!--
**Please explain the purpose of your changes**, for example:

This PR addresses a privacy risk associated with writing logs to disk, where sensitive information about a client's traffic history could potentially be exposed to third parties - either located on the client's computer or during transmission for debugging purposes.

To mitigate this risk, the PR introduces a new logger.Redacted function, which enables us to easily redact sensitive data from production logs.
-->

This PR updates outdated filter list URL for the Hungarian filter list to https://filters.hufilter.hu/hufilter-adguard.txt.

### How did you verify your code works?
Verified that the application runs without errors after the update.
<!--
**Please describe your testing strategy**:

- If you performed manual testing, list the steps to verify correct functionality, including edge cases if applicable.
- If new or existing automated tests cover the functionality, explicitly mention them.
-->

### What are the relevant issues?
Closes #296 
<!--
**Please link any relevant issues**, for example:

Closes #123
-->
