### PR TITLE
Fix scriptlet exceptions

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ZenPrivacy/zen-desktop/internal/jsrule"
 	"github.com/ZenPrivacy/zen-desktop/internal/logger"
 	"github.com/ZenPrivacy/zen-desktop/internal/networkrules/rule"
+	"github.com/ZenPrivacy/zen-desktop/internal/scriptlet"
 )
 
 // filterEventsEmitter emits filter events.
@@ -83,8 +84,6 @@ type Filter struct {
 var (
 	// ignoreLineRegex matches comments and [Adblock Plus 2.0]-style headers.
 	ignoreLineRegex = regexp.MustCompile(`^(?:!|\[|#[^#%@$])`)
-	// scriptletRegex matches scriptlet rules.
-	scriptletRegex = regexp.MustCompile(`(?:#%#\/\/scriptlet)|(?:##\+js)`)
 )
 
 // NewFilter creates and initializes a new filter.
@@ -210,7 +209,7 @@ func (f *Filter) AddRule(rule string, filterListName *string, filterListTrusted 
 		Therefore, we must first check for a scriptlet rule match before checking for a JS rule match.
 	*/
 	switch {
-	case scriptletRegex.MatchString(rule):
+	case scriptlet.RuleRegex.MatchString(rule):
 		if err := f.scriptletsInjector.AddRule(rule, filterListTrusted); err != nil {
 			return false, fmt.Errorf("add scriptlet: %w", err)
 		}

--- a/internal/scriptlet/addrule.go
+++ b/internal/scriptlet/addrule.go
@@ -9,6 +9,8 @@ import (
 // TODO: rethink and reimplement trusted rule handling.
 
 var (
+	RuleRegex = regexp.MustCompile(`(?:#@?%#\/\/scriptlet)|(?:#@?#\+js)`)
+
 	canonicalPrimary        = regexp.MustCompile(`(.*)#%#\/\/scriptlet\((.+)\)`)
 	canonicalExceptionRegex = regexp.MustCompile(`(.*)#@%#\/\/scriptlet\((.+)\)`)
 	ublockPrimaryRegex      = regexp.MustCompile(`(.*)##\+js\((.+)\)`)

--- a/internal/scriptlet/addrule.go
+++ b/internal/scriptlet/addrule.go
@@ -9,6 +9,9 @@ import (
 // TODO: rethink and reimplement trusted rule handling.
 
 var (
+	// RuleRegex matches patterns for scriptlet rules in two formats:
+	// 1. `#%#//scriptlet` or `#@%#//scriptlet` for canonical rules.
+	// 2. `##+js` or `#@#+js` for uBlock-style rules.
 	RuleRegex = regexp.MustCompile(`(?:#@?%#\/\/scriptlet)|(?:#@?#\+js)`)
 
 	canonicalPrimary        = regexp.MustCompile(`(.*)#%#\/\/scriptlet\((.+)\)`)

--- a/internal/scriptlet/addrule.go
+++ b/internal/scriptlet/addrule.go
@@ -10,8 +10,9 @@ import (
 
 var (
 	// RuleRegex matches patterns for scriptlet rules in two formats:
-	// 1. `#%#//scriptlet` or `#@%#//scriptlet` for canonical rules.
-	// 2. `##+js` or `#@#+js` for uBlock-style rules.
+	//
+	//  1. #%#//scriptlet or #@%#//scriptlet for canonical rules.
+	//  2. ##+js or #@#+js for uBlock-style rules.
 	RuleRegex = regexp.MustCompile(`(?:#@?%#\/\/scriptlet)|(?:#@?#\+js)`)
 
 	canonicalPrimary        = regexp.MustCompile(`(.*)#%#\/\/scriptlet\((.+)\)`)


### PR DESCRIPTION
### What does this PR do?
- Fixes scriptlet exceptions by including exception syntax in the top-level matching regex.
- Optimizes hostmatcher.Get.

### How did you verify your code works?
Existing unit tests, manual testing.

### What are the relevant issues?
resolves #323 
