### PR TITLE
Include noselfupdate macOS production build in build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,7 @@ jobs:
           CERTIFICATE=$CERTIFICATE \
           CERTIFICATE_PWD=$CERTIFICATE_PWD \
           task build:setup-keychain
-      - name: Build macOS App & Installer
-        if: runner.os == 'macOS'
+      - name: Build & archive macOS artifacts
         env:
           CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
           NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
@@ -101,10 +100,15 @@ jobs:
           NOTARIZATION_TEAM_ID=$NOTARIZATION_TEAM_ID \
           NOTARIZATION_PWD=$NOTARIZATION_PWD \
           task build:prod ARCH=${{ matrix.arch }}
-      - name: Archive macOS artifacts
-        run: |
           tar -czvf Zen_darwin_${{ matrix.arch }}.tar.gz -C build/bin Zen.app
           mv build/bin/Zen.dmg build/bin/Zen-${{ matrix.arch }}.dmg
+
+          CERTIFICATE_NAME=$CERTIFICATE_NAME \
+          NOTARIZATION_APPLE_ID=$NOTARIZATION_APPLE_ID \
+          NOTARIZATION_TEAM_ID=$NOTARIZATION_TEAM_ID \
+          NOTARIZATION_PWD=$NOTARIZATION_PWD \
+          task build:prod-noupdate ARCH=${{ matrix.arch }}
+          tar -czvf Zen_darwin_${{ matrix.arch }}_noselfupdate.tar.gz -C build/bin Zen.app
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -112,6 +116,7 @@ jobs:
           path: |
             Zen_darwin_${{ matrix.arch }}.tar.gz
             build/bin/Zen-${{ matrix.arch }}.dmg
+            Zen_darwin_${{ matrix.arch }}_noselfupdate.tar.gz
 
   build-windows:
     name: Build Windows (${{ matrix.arch }})

--- a/tasks/build/Taskfile-darwin.yml
+++ b/tasks/build/Taskfile-darwin.yml
@@ -26,6 +26,17 @@ tasks:
         vars:
           FILENAME: build/bin/Zen.dmg
 
+  prod-noupdate:
+    desc: Create a production build of the application with self-updates disabled. Only recommended for use in CI/CD pipelines. Doesn't include a DMG installer.
+    cmds:
+      - task: app-noupdate
+      - task: codesign
+        vars:
+          FILENAME: build/bin/Zen.app
+      - task: notarize
+        vars:
+          FILENAME: build/bin/Zen.app
+
   deps:
     desc: Install the dependencies required to create a production build.
     cmds:
@@ -35,6 +46,11 @@ tasks:
     desc: Build the .app application bundle. The .app file will be placed in the build/bin directory.
     cmds:
       - wails build -platform "darwin/{{default .ARCH64 .ARCH}}" -m -skipbindings -ldflags "-X 'github.com/ZenPrivacy/zen-desktop/internal/cfg.Version={{.GIT_TAG}}'" -tags prod
+
+  app-noupdate:
+    desc: Build the .app application bundle with self-updates disabled. The .app file will be placed in the build/bin directory.
+    cmds:
+      - wails build -platform "darwin/{{default .ARCH64 .ARCH}}" -m -skipbindings -ldflags "-X 'github.com/ZenPrivacy/zen-desktop/internal/cfg.Version={{.GIT_TAG}}' -X 'github.com/ZenPrivacy/zen-desktop/internal/selfupdate.NoSelfUpdate=true'" -tags prod
 
   dmg:
     desc: Create a DMG installer for the application. The DMG file will be placed in the build/bin directory.


### PR DESCRIPTION
### What does this PR do?
Adds macOS `.app` version with self-updates disabled.

### How did you verify your code works?
CI runs.

### What are the relevant issues?
Sets the ground up for #81.