### PR TITLE
Add payment-related hosts to exclusions lists

### DIFF
--- a/internal/sysproxy/exclusions/common.txt
+++ b/internal/sysproxy/exclusions/common.txt
@@ -42,6 +42,7 @@ freedompay.kz
 # Payment processors
 paypal.com
 stripe.com
+m.stripe.network
 square.com
 venmo.com
 sis.redsys.es

--- a/internal/sysproxy/exclusions/common.txt
+++ b/internal/sysproxy/exclusions/common.txt
@@ -44,6 +44,7 @@ paypal.com
 stripe.com
 square.com
 venmo.com
+sis.redsys.es
 
 # Messengers
 whatsapp.net

--- a/internal/sysproxy/exclusions/darwin.txt
+++ b/internal/sysproxy/exclusions/darwin.txt
@@ -152,3 +152,20 @@ apple-relay.apple.com
 # Associated domains
 app-site-association.cdn-apple.com
 app-site-association.networking.apple
+
+# Apple Pay, and likely other services (not present in the support article, found via manual debugging)
+pr-pod1-smp-device.apple.com
+pr-pod2-smp-device.apple.com
+pr-pod3-smp-device.apple.com
+pr-pod4-smp-device.apple.com
+pr-pod5-smp-device.apple.com
+pr-pod6-smp-device.apple.com
+pr-pod7-smp-device.apple.com
+pr-pod8-smp-device.apple.com
+pr-pod9-smp-device.apple.com
+pr-pod10-smp-device.apple.com
+pr-pod11-smp-device.apple.com
+pr-pod12-smp-device.apple.com
+pr-pod13-smp-device.apple.com
+pr-pod14-smp-device.apple.com
+pr-pod15-smp-device.apple.com

--- a/internal/sysproxy/exclusions/darwin.txt
+++ b/internal/sysproxy/exclusions/darwin.txt
@@ -169,3 +169,5 @@ pr-pod12-smp-device.apple.com
 pr-pod13-smp-device.apple.com
 pr-pod14-smp-device.apple.com
 pr-pod15-smp-device.apple.com
+smp-paymentservices.apple.com
+cn-smp-paymentservices.apple.com


### PR DESCRIPTION
### What does this PR do?
- Adds `sys.redsys.es`, a Spanish payment provider website, and Stripe's `m.stripe.network` to the common proxy exclusions list
- Adds Apple Pay related hosts to the macOS exclusions list

### How did you verify your code works?
Manual testing

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
