### PR TITLE
Added OpenAI domains to default ignored hosts

### DIFF
--- a/internal/sysproxy/exclusions/common.txt
+++ b/internal/sysproxy/exclusions/common.txt
@@ -81,6 +81,24 @@ pypi.org
 crates.io
 rubygems.org
 
+# OpenAI from here: https://help.openai.com/en/articles/9247338-network-recommendations-for-chatgpt-errors-on-web-and-apps
+openai.com
+chatgpt.com
+oaiusercontent.com
+oaistatic.com
+statsig.com
+statsigapi.net
+featuregates.org
+intercomcdn.com
+js.intercomcdn.com
+intercom.io
+js.stripe.com
+challenges.cloudflare.com
+rum.browser-intake-datadoghq.com
+o33249.ingest.sentry.io
+prodregistryv2.org
+featureassets.org
+
 # Issues
 # https://github.com/ZenPrivacy/zen-desktop/pull/223
 account.booking.com

--- a/internal/sysproxy/exclusions/common.txt
+++ b/internal/sysproxy/exclusions/common.txt
@@ -82,22 +82,9 @@ crates.io
 rubygems.org
 
 # OpenAI from here: https://help.openai.com/en/articles/9247338-network-recommendations-for-chatgpt-errors-on-web-and-apps
-openai.com
-chatgpt.com
+ios.chat.openai.com
+ab.chatgpt.com
 oaiusercontent.com
-oaistatic.com
-statsig.com
-statsigapi.net
-featuregates.org
-intercomcdn.com
-js.intercomcdn.com
-intercom.io
-js.stripe.com
-challenges.cloudflare.com
-rum.browser-intake-datadoghq.com
-o33249.ingest.sentry.io
-prodregistryv2.org
-featureassets.org
 
 # Issues
 # https://github.com/ZenPrivacy/zen-desktop/pull/223


### PR DESCRIPTION
added Openai's list of urls

### What does this PR do?

It adds openAI's list of domains to the default list of Ignored hosts. got them from here:
https://help.openai.com/en/articles/9247338-network-recommendations-for-chatgpt-errors-on-web-and-apps

### How did you verify your code works?

tested them in ignored hosts on the app.
