### PR TITLE
Patch broken RU AdList link, update Icelandic list

### DIFF
--- a/internal/cfg/default-config.json
+++ b/internal/cfg/default-config.json
@@ -154,8 +154,8 @@
         "type": "regional"
       },
       {
-        "url": "https://adblock.gardar.net/is.abp.txt",
-        "name": "🇮🇸IS: Icelandic ABP List",
+        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/custom/is.txt",
+        "name": "🇮🇸IS: Adblock listi fyrir íslenskar vefsíður",
         "enabled": false,
         "type": "regional"
       },
@@ -232,7 +232,7 @@
         "type": "regional"
       },
       {
-        "url": "https://easylist-downloads.adblockplus.org/ruadlist.txt",
+        "url": "https://raw.githubusercontent.com/dimisa-RUAdList/RUAdListCDN/refs/heads/main/lists/ruadlist.ubo.min.txt",
         "name": "🇷🇺RU 🇺🇦UA 🇺🇿UZ 🇰🇿KZ: RU AdList",
         "enabled": false,
         "type": "regional"

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -103,6 +103,23 @@ var migrations = map[string]func(c *Config) error{
 		}
 		return nil
 	},
+	"v0.11.0": func(c *Config) error {
+		for i, list := range c.Filter.FilterLists {
+			if list.URL == "https://adblock.gardar.net/is.abp.txt" {
+				c.Filter.FilterLists[i].URL = "https://raw.githubusercontent.com/brave/adblock-lists/master/custom/is.txt"
+				c.Filter.FilterLists[i].Name = "🇮🇸IS: Adblock listi fyrir íslenskar vefsíður"
+				log.Printf("v0.11.0 migration: updating the Icelandic list's URL and name")
+			}
+			if list.URL == "https://easylist-downloads.adblockplus.org/ruadlist.txt" {
+				c.Filter.FilterLists[i].URL = "https://raw.githubusercontent.com/dimisa-RUAdList/RUAdListCDN/refs/heads/main/lists/ruadlist.ubo.min.txt"
+				log.Printf("v0.11.0 migration: updating the RU AdList's URL")
+			}
+		}
+		if err := c.Save(); err != nil {
+			return fmt.Errorf("save config: %v", err)
+		}
+		return nil
+	},
 }
 
 // RunMigrations runs the version-to-version migrations.


### PR DESCRIPTION
### What does this PR do?
Updates the `default-config.json` and introduces the `v0.11.0` migration with:
- A fix for a non-functional link to the RU AdList
- A replacement for the discontinued Icelandic list, following uBlock’s update: https://github.com/gorhill/uBlock/pull/3920

### How did you verify your code works?


### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
