### PR TITLE
Add handling for 'unsafe-inline' in CSP header processing

### DIFF
--- a/internal/scriptlet/injector.go
+++ b/internal/scriptlet/injector.go
@@ -131,6 +131,8 @@ outer:
 
 		token := " 'nonce-" + nonce + "'"
 		switch {
+		case strings.Contains(strings.ToLower(p), "'unsafe-inline'"):
+			// Intentionally empty. 'unsafe-inline' allows the execution of inline scripts, and is incompatible with 'nonce-' directives.
 		case strings.Contains(strings.ToLower(p), "'none'"):
 			parts[i] = strings.Replace(p, "'none'", token, 1)
 		default:


### PR DESCRIPTION
### What does this PR do?
Fixes CSP header injection behavior when `'unsafe-inline'` directive is already present.

From https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#nonce-nonce_value:
> If a directive contains a nonce and unsafe-inline, then the browser ignores unsafe-inline.

### How did you verify your code works?
Manual testing.

### What are the relevant issues?
