### PR TITLE
Fix CSP modification

### DIFF
--- a/internal/scriptlet/injector.go
+++ b/internal/scriptlet/injector.go
@@ -131,7 +131,7 @@ outer:
 
 		token := " 'nonce-" + nonce + "'"
 		switch {
-		case strings.Contains(strings.ToLower(p), "'unsafe-inline'"):
+		case strings.Contains(p, "'unsafe-inline'") && !strings.Contains(p, "'strict-dynamic'"):
 			// Intentionally empty. 'unsafe-inline' allows the execution of inline scripts, and is incompatible with 'nonce-' directives.
 		case strings.Contains(strings.ToLower(p), "'none'"):
 			parts[i] = strings.Replace(p, "'none'", token, 1)


### PR DESCRIPTION
### What does this PR do?

Improves handling of the `unsafe-inline` case. According to the CSP documentation, `unsafe-inline` must be combined with `strict-dynamic` to be considered valid. This update ensures that we only modify directives that meet this requirement.
Reference: [https://content-security-policy.com/unsafe-inline/](https://content-security-policy.com/unsafe-inline/) (see the "When is it ok to use unsafe-inline?" section)

### How did you verify your code works?

Manual testing:
- Reddit injections work
- DuckDuckGo search works
