### PR TITLE
Fix argument parsing to support both short and long flags for start and hidden; fix second instance args processing

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -385,15 +385,14 @@ func (a *App) OnSecondInstanceLaunch(secondInstanceData options.SecondInstanceDa
 	if start {
 		a.StartProxy()
 	}
-
 }
 
 func parseLaunchArgs(args []string) (start, hidden bool) {
-	for _, arg := range args[1:] {
-		if arg == "-start" {
+	for _, arg := range args {
+		if arg == "-start" || arg == "--start" {
 			start = true
 		}
-		if arg == "-hidden" {
+		if arg == "-hidden" || arg == "--hidden" {
 			hidden = true
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
Mostly self-explanatory. `secondInstanceData.Args` contains arguments without the binary path as the first element, so we need to check every position to properly process the arguments.

### How did you verify your code works?
Manual testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
