### PR TITLE
delete disabled from copy and goTo buttons

### DIFF
--- a/frontend/src/FilterLists/index.tsx
+++ b/frontend/src/FilterLists/index.tsx
@@ -165,7 +165,6 @@ function ListItem({
             icon="duplicate"
             intent="none"
             className="filter-lists__list-button"
-            disabled={isProxyRunning}
             onClick={async () => {
               try {
                 await navigator.clipboard.writeText(filterList.url);
@@ -184,7 +183,6 @@ function ListItem({
           icon="globe-network"
           intent="none"
           className="filter-lists__list-button"
-          disabled={isProxyRunning}
           onClick={() => {
             BrowserOpenURL(filterList.url);
           }}


### PR DESCRIPTION
### What does this PR do?

This PR removes the `disabled` property from the `copy` and `goTo` buttons.  
As a result, these buttons are now always interactive, regardless of previous conditional states that may have blocked user actions.

### How did you verify your code works?

- Manual testing.

### What are the relevant issues?

Closes #417