### PR TITLE
Implement robust logic for scriptlet argument splitting

### DIFF
--- a/internal/scriptlet/arglist.go
+++ b/internal/scriptlet/arglist.go
@@ -7,10 +7,12 @@ import (
 )
 
 // argList represents the argument list of a scriptlet, excluding the function call expression.
+//
+// The string representing argList must be non-empty.
 type argList string
 
 func (al argList) ConvertUboToCanonical() argList {
-	args := strings.Split(string(al), ",")
+	args := argSplit(string(al))
 	for i := range args {
 		// uBo scriptlets may use both quoted and unquoted strings.
 		if !isQuoted(args[i]) {
@@ -21,7 +23,7 @@ func (al argList) ConvertUboToCanonical() argList {
 }
 
 func (al argList) Normalize() (argList, error) {
-	args := strings.Split(string(al), ",")
+	args := argSplit(string(al))
 	var normalized string
 	for i, arg := range args {
 		arg = strings.TrimSpace(arg)
@@ -43,7 +45,7 @@ func (al argList) Normalize() (argList, error) {
 func (al argList) IsTrusted() bool {
 	const trustedPrefix = "trusted-"
 
-	firstArg := strings.Split(string(al), ",")[0]
+	firstArg := argSplit(string(al))[0]
 	unquoted := firstArg[1 : len(firstArg)-1]
 	return strings.HasPrefix(unquoted, trustedPrefix)
 }

--- a/internal/scriptlet/arglist_test.go
+++ b/internal/scriptlet/arglist_test.go
@@ -36,9 +36,10 @@ func TestNormalize(t *testing.T) {
 		testCases := []string{
 			`"arg1", "arg2`,
 			`"`,
-			``,
 			`"""`,
-			``,
+			` `,
+			`"arg1\", "arg2"`,
+			`"arg1", ,"arg2"`,
 		}
 
 		for _, test := range testCases {

--- a/internal/scriptlet/argsplit.go
+++ b/internal/scriptlet/argsplit.go
@@ -1,0 +1,64 @@
+package scriptlet
+
+import "strings"
+
+// argSplit splits a list of strings by commas, respecting commas inside quoted strings
+// and backslash-escaped commas.
+func argSplit(input string) []string {
+	if input == "" {
+		return []string{}
+	}
+
+	var (
+		res                     []string
+		b                       strings.Builder
+		inSingle, inDouble, esc bool
+	)
+
+	flush := func() {
+		s := b.String()
+		b.Reset()
+
+		s = strings.TrimSpace(s)
+		res = append(res, s)
+	}
+
+	for _, c := range input {
+		if esc {
+			b.WriteByte('\\')
+			b.WriteRune(c)
+			esc = false
+			continue
+		}
+
+		switch c {
+		case '\\':
+			esc = true
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+			b.WriteRune(c)
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+			b.WriteRune(c)
+		case ',':
+			if inSingle || inDouble {
+				b.WriteRune(c)
+			} else {
+				flush()
+			}
+		default:
+			b.WriteRune(c)
+		}
+	}
+
+	if esc {
+		b.WriteByte('\\')
+	}
+	flush()
+
+	return res
+}

--- a/internal/scriptlet/argsplit_test.go
+++ b/internal/scriptlet/argsplit_test.go
@@ -1,0 +1,34 @@
+package scriptlet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestArgSplit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected []string
+	}{
+		{"", []string{}},
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a ,  b  , c ", []string{"a", "b", "c"}},
+		{`"a, b",c`, []string{`"a, b"`, "c"}},
+		{`'a, b', c`, []string{"'a, b'", "c"}},
+		{`a\,b,c`, []string{`a\,b`, "c"}},
+		{`a\\,b`, []string{`a\\`, "b"}},
+		{`"\"hi\"",x`, []string{`"\"hi\""`, "x"}},
+		{`'it\'s fine',y`, []string{`'it\'s fine'`, "y"}},
+		{"a,", []string{"a", ""}},
+		{`" spaced " , unquoted`, []string{`" spaced "`, "unquoted"}},
+	}
+
+	for _, test := range testCases {
+		got := argSplit(test.input)
+		if !reflect.DeepEqual(got, test.expected) {
+			t.Errorf("argSplit(%q) = %q, want %q", test.input, got, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?
As described in #399, current scriptlet argument splitting logic is error-prone. This PR introduces a state-machine-based parser that robustly handles commas inside quoted strings.

### How did you verify your code works?
New and existing unit tests.

### What are the relevant issues?
closes #399 