### PR TITLE
Fix proxy startup on autostart on macOS

### DIFF
--- a/internal/autostart/autostart_darwin.go
+++ b/internal/autostart/autostart_darwin.go
@@ -28,6 +28,7 @@ const (
 		<string>{{.Program}}</string>
 		<key>ProgramArguments</key>
 		<array>
+			<string>{{.Program}}</string>
 			<string>--start</string>
 		</array>
 		<key>RunAtLoad</key>

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -140,7 +140,7 @@ var migrations = map[string]func(c *Config) error{
 		}
 		return nil
 	},
-	"v0.12.0": func(c *Config) error {
+	"v0.12.0": func(_ *Config) error {
 		if runtime.GOOS == "darwin" {
 			autostart := autostart.Manager{}
 			enabled, err := autostart.IsEnabled()

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -140,6 +140,26 @@ var migrations = map[string]func(c *Config) error{
 		}
 		return nil
 	},
+	"v0.12.0": func(c *Config) error {
+		if runtime.GOOS == "darwin" {
+			autostart := autostart.Manager{}
+			enabled, err := autostart.IsEnabled()
+			if err != nil {
+				return fmt.Errorf("check enabled: %v", err)
+			}
+			if enabled {
+				// Re-enable to update ProgramArguments
+				if err := autostart.Disable(); err != nil {
+					return fmt.Errorf("disable autostart: %v", err)
+				}
+				if err := autostart.Enable(); err != nil {
+					return fmt.Errorf("enable autostart: %v", err)
+				}
+			}
+		}
+
+		return nil
+	},
 }
 
 // RunMigrations runs the version-to-version migrations.


### PR DESCRIPTION
### What does this PR do?
The PR fixes the issue where the proxy failed to start up on autostart on macOS.

The issue was with the `ProgramArguments` key in launchd daemon. This key defines the argument array passed to the program. Previously, the array contained only a single element, `--start`, at position 0. In Go, these values become `os.Args`, but the flag package ignores the zeroth element (https://go.dev/src/flag/flag.go#L1188), causing the `--start` flag to be missed.

By adding the program path as the zeroth element, where it belongs, we ensure the flag parser receives `--start` as the first real argument, allowing the app to start the proxy correctly on autostart.

See more on this here:
https://apple.stackexchange.com/questions/110644/getting-launchd-to-read-program-arguments-correctly

### How did you verify your code works?
Manual testing.

### What are the relevant issues?

