### PR TITLE
Block page

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ZenPrivacy/zen-desktop/internal/cssrule"
 	"github.com/ZenPrivacy/zen-desktop/internal/filter"
 	"github.com/ZenPrivacy/zen-desktop/internal/filter/filterliststore"
+	"github.com/ZenPrivacy/zen-desktop/internal/filter/whitelistserver"
 	"github.com/ZenPrivacy/zen-desktop/internal/jsrule"
 	"github.com/ZenPrivacy/zen-desktop/internal/logger"
 	"github.com/ZenPrivacy/zen-desktop/internal/networkrules"
@@ -49,6 +50,7 @@ type App struct {
 	certStore       *certstore.DiskCertStore
 	systrayMgr      *systray.Manager
 	filterListStore *filterliststore.FilterListStore
+	whitelistSrv    *whitelistserver.Server
 }
 
 // NewApp initializes the app.
@@ -186,11 +188,17 @@ func (a *App) StartProxy() (err error) {
 	cosmeticRulesInjector := cosmetic.NewInjector()
 	cssRulesInjector := cssrule.NewInjector()
 	jsRuleInjector := jsrule.NewInjector()
+	whitelistSrv := whitelistserver.New(networkRules)
 
-	filter, err := filter.NewFilter(a.config, networkRules, scriptletInjector, cosmeticRulesInjector, cssRulesInjector, jsRuleInjector, a.eventsHandler, a.filterListStore)
+	filter, err := filter.NewFilter(a.config, networkRules, scriptletInjector, cosmeticRulesInjector, cssRulesInjector, jsRuleInjector, a.eventsHandler, a.filterListStore, whitelistSrv)
 	if err != nil {
 		return fmt.Errorf("create filter: %v", err)
 	}
+
+	if err := whitelistSrv.Start(); err != nil {
+		return fmt.Errorf("start whitelist server: %v", err)
+	}
+	a.whitelistSrv = whitelistSrv
 
 	certGenerator, err := certgen.NewCertGenerator(a.certStore)
 	if err != nil {
@@ -265,6 +273,12 @@ func (a *App) StopProxy() (err error) {
 	if err := a.proxy.Stop(); err != nil {
 		return fmt.Errorf("stop proxy: %w", err)
 	}
+
+	if err := a.whitelistSrv.Stop(); err != nil {
+		return fmt.Errorf("stop whitelist server: %w", err)
+	}
+
+	a.whitelistSrv = nil
 	a.proxy = nil
 	a.proxyOn = false
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ZenPrivacy/zen-desktop/internal/cfg"
 	"github.com/ZenPrivacy/zen-desktop/internal/cosmetic"
 	"github.com/ZenPrivacy/zen-desktop/internal/cssrule"
+	"github.com/ZenPrivacy/zen-desktop/internal/filter/unblockserver"
 	"github.com/ZenPrivacy/zen-desktop/internal/jsrule"
 	"github.com/ZenPrivacy/zen-desktop/internal/logger"
 	"github.com/ZenPrivacy/zen-desktop/internal/networkrules"
@@ -176,6 +177,9 @@ func (f *Filter) init() {
 	if len(myRules) > 0 {
 		log.Printf("filter initialization: added %d rules and %d exceptions from %q", ruleCount, exceptionCount, filterName)
 	}
+
+	srv := unblockserver.NewServer(f.networkRules)
+	srv.Start(33669)
 }
 
 // ParseAndAddRules parses the rules from the given reader and adds them to the filter.

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -179,7 +179,7 @@ func (f *Filter) init() {
 	}
 
 	srv := unblockserver.NewServer(f.networkRules)
-	srv.Start(33669)
+	srv.Start()
 }
 
 // ParseAndAddRules parses the rules from the given reader and adds them to the filter.

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -256,6 +256,12 @@ func (f *Filter) HandleRequest(req *http.Request) (*http.Response, error) {
 		f.eventsEmitter.OnFilterBlock(req.Method, initialURL, req.Header.Get("Referer"), appliedRules)
 
 		if isUserNavigation(req) {
+			port := f.whitelistSrv.GetPort()
+			if port <= 0 {
+				log.Printf("whitelist server not ready, falling back to simple block response for %q", logger.Redacted(req.URL))
+				return f.networkRules.CreateBlockResponse(req), nil
+			}
+
 			res, err := f.networkRules.CreateBlockPageResponse(req, appliedRules, f.whitelistSrv.GetPort())
 			if err != nil {
 				return nil, fmt.Errorf("create block page response: %v", err)

--- a/internal/filter/unblockserver/server.go
+++ b/internal/filter/unblockserver/server.go
@@ -1,0 +1,83 @@
+package unblockserver
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Server struct {
+	networkRules networkRules
+	httpSrv      *http.Server
+}
+
+type networkRules interface {
+	ParseRule(rule string, filterName *string) (isException bool, err error)
+}
+
+func NewServer(nr networkRules) *Server {
+	return &Server{networkRules: nr}
+}
+
+func (s *Server) handleUnblock(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+	host := strings.ToLower(r.URL.Query().Get("host"))
+	if host == "" {
+		http.Error(w, "missing host", http.StatusBadRequest)
+		return
+	}
+
+	rule := fmt.Sprintf("@@||%s^", host)
+
+	filterList := "allowed-list"
+	if _, err := s.networkRules.ParseRule(rule, &filterList); err != nil {
+		http.Error(w, "networkrules: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("unblocked " + host))
+}
+
+func (s *Server) Start(port int) (int, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/unblock", s.handleUnblock)
+
+	s.httpSrv = &http.Server{
+		Handler:      mux,
+		ReadTimeout:  time.Minute,
+		WriteTimeout: time.Minute,
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return -1, fmt.Errorf("listen: %w", err)
+	}
+	actualPort := listener.Addr().(*net.TCPAddr).Port
+	log.Printf("Unblock server listening on port %d", actualPort)
+
+	go func() {
+		if err := s.httpSrv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Printf("error serving unblock: %v", err)
+		}
+	}()
+
+	return actualPort, nil
+}
+
+func (s *Server) Stop() error {
+	if s.httpSrv != nil {
+		return s.httpSrv.Close()
+	}
+	return nil
+}

--- a/internal/filter/whitelistserver/server.go
+++ b/internal/filter/whitelistserver/server.go
@@ -28,36 +28,6 @@ func (s *Server) handleAllow(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
 
-	if r.Method == http.MethodGet {
-		rule := r.URL.Query().Get("rule")
-		returnTo := r.URL.Query().Get("returnTo")
-
-		if rule == "" {
-			http.Error(w, "missing rule", http.StatusBadRequest)
-			return
-		}
-		if returnTo == "" {
-			http.Error(w, "missing returnTo", http.StatusBadRequest)
-			return
-		}
-
-		filterList := "Allowlist"
-		if _, err := s.networkRules.ParseRule(fmt.Sprintf("@@%s", rule), &filterList); err != nil {
-			http.Error(w, "networkrules: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if u, err := url.Parse(returnTo); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
-			http.Redirect(w, r, returnTo, http.StatusSeeOther)
-			return
-		}
-	}
-
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
 	switch r.Method {
 	case http.MethodGet:
 		rule := r.URL.Query().Get("rule")

--- a/internal/filter/whitelistserver/server.go
+++ b/internal/filter/whitelistserver/server.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -42,7 +41,7 @@ func (s *Server) handleAllow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rule := strings.ToLower(r.FormValue("rule"))
+	rule := r.FormValue("rule")
 	if rule == "" {
 		http.Error(w, "missing rule", http.StatusBadRequest)
 		return

--- a/internal/filter/whitelistserver/server.go
+++ b/internal/filter/whitelistserver/server.go
@@ -27,15 +27,20 @@ func (s *Server) handleAllow(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "invalid form", http.StatusBadRequest)
 		return
@@ -53,6 +58,7 @@ func (s *Server) handleAllow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("allowed rule: " + html.EscapeString(rule)))
 }

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -67,6 +67,7 @@
         <h1>Blocked by Zen</h1>
         <p><strong>URL:</strong> <code>{{ .URL }}</code></p>
         {{ if .Rule }}
+        <input type="hidden" id="rule" value="{{ .Rule }}" />
         <p><strong>Rule:</strong> <code>{{ .Rule }}</code></p>
         {{ end }} {{ if .FilterList }}
         <p><strong>Found in:</strong> {{ .FilterList }}</p>
@@ -79,20 +80,14 @@
       </div>
     </div>
     <script>
-      function proceed() {
-        const host = location.hostname;
-        fetch(
-          `http://127.0.0.1:33669/unblock?host=${encodeURIComponent(host)}`,
-          {
-            method: 'GET',
-          }
-        )
-          .then(() => {
-            window.location.reload();
-          })
-          .catch((err) => {
-            console.error('Unblock failed:', err);
-          });
+      async function proceed() {
+        const rule = document.querySelector('#rule').value;
+        await fetch('http://127.0.0.1:33669/allow-rule', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'rule=' + encodeURIComponent(rule),
+        });
+        window.location.reload();
       }
     </script>
   </body>

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -69,30 +69,22 @@
         {{ end }}
 
         <div class="actions">
-          <a class="btn" onclick="allow()">Allow</a>
+          <a id="allowLink" class="btn" onclick="allow()">Allow</a>
           <a class="btn secondary" onclick="window.history.back()">Go back</a>
         </div>
-        <div id="rule" data-rule="{{ .Rule }}"></div>
       </div>
     </div>
     <script>
-      const rule = document.getElementById('rule').dataset.rule;
       document.getElementById('url').textContent = window.location.toString();
 
-      async function allow() {
-        try {
-          await fetch(`http://127.0.0.1:{{ .WhitelistPort }}/allow-rule`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: 'rule=' + encodeURIComponent(rule),
-            mode: 'no-cors',
-          });
-          window.location.reload();
-        } catch (err) {
-          console.log('Error allowing rule:', err);
-          alert('Error allowing rule');
-        }
-      }
+      const rule = '{{ .Rule }}';
+      const returnTo = encodeURIComponent(location.href);
+
+      document.getElementById(
+        'allowLink'
+      ).href = `http://127.0.0.1:{{ .WhitelistPort }}/allow-rule?rule=${encodeURIComponent(
+        rule
+      )}&returnTo=${returnTo}`;
     </script>
   </body>
 </html>

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -54,6 +54,7 @@
         color: #fff;
         text-decoration: none;
         display: inline-block;
+        cursor: pointer;
       }
       .btn.secondary {
         background: #e5e7eb;
@@ -67,25 +68,31 @@
         <h1>Blocked by Zen</h1>
         <p><strong>URL:</strong> <code>{{ .URL }}</code></p>
         {{ if .Rule }}
-        <input type="hidden" id="rule" value="{{ .Rule }}" />
         <p><strong>Rule:</strong> <code>{{ .Rule }}</code></p>
         {{ end }} {{ if .FilterList }}
         <p><strong>Found in:</strong> {{ .FilterList }}</p>
         {{ end }}
 
         <div class="actions">
-          <a class="btn" style="cursor: pointer" onclick="proceed()">Proceed</a>
-          <span class="btn secondary">Go back</span>
+          <a class="btn" onclick="allow()">Allow</a>
+          <button
+            class="btn secondary"
+            type="button"
+            onclick="window.history.back()"
+          >
+            Go back
+          </button>
         </div>
       </div>
     </div>
     <script>
-      async function proceed() {
-        const rule = document.querySelector('#rule').value;
-        await fetch('http://127.0.0.1:33669/allow-rule', {
+      async function allow() {
+        const url = `http://127.0.0.1:{{ .WhitelistPort }}/allow-rule`;
+
+        await fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: 'rule=' + encodeURIComponent(rule),
+          body: 'rule=' + encodeURIComponent(`{{ .Rule }}`),
         });
         window.location.reload();
       }

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Request blocked</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-store" />
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+          Helvetica, Arial, sans-serif;
+        background: #f6f7fb;
+        margin: 0;
+        color: #111;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 7vh auto;
+        padding: 24px;
+      }
+      .card {
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 2px 14px rgba(0, 0, 0, 0.06);
+        padding: 28px;
+      }
+      h1 {
+        margin: 0 0 12px 0;
+        font-size: 22px;
+      }
+      code,
+      pre {
+        background: #f3f4f6;
+        border-radius: 6px;
+        padding: 2px 6px;
+      }
+      .meta {
+        margin-top: 16px;
+        font-size: 14px;
+        color: #555;
+      }
+      .actions {
+        margin-top: 24px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .btn {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        padding: 10px 14px;
+        background: #2d6cdf;
+        color: #fff;
+        text-decoration: none;
+        display: inline-block;
+      }
+      .btn.secondary {
+        background: #e5e7eb;
+        color: #111;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <h1>Blocked by Zen</h1>
+        <p><strong>URL:</strong> <code>{{ .URL }}</code></p>
+        {{ if .Rule }}
+        <p><strong>Rule:</strong> <code>{{ .Rule }}</code></p>
+        {{ end }} {{ if .FilterList }}
+        <p><strong>Found in:</strong> {{ .FilterList }}</p>
+        {{ end }}
+
+        <div class="actions">
+          <a
+            class="btn"
+            style="cursor: pointer"
+            onclick="console.log('unblock')"
+            >Proceed</a
+          >
+          <span class="btn secondary">Go back</span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -72,9 +72,11 @@
           <a class="btn" onclick="allow()">Allow</a>
           <a class="btn secondary" onclick="window.history.back()">Go back</a>
         </div>
+        <div id="rule" data-rule="{{ .Rule }}"></div>
       </div>
     </div>
     <script>
+      const rule = document.getElementById('rule').dataset.rule;
       document.getElementById('url').textContent = window.location.toString();
 
       async function allow() {
@@ -82,7 +84,7 @@
           await fetch(`http://127.0.0.1:{{ .WhitelistPort }}/allow-rule`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: 'rule=' + encodeURIComponent(`{{ .Rule }}`),
+            body: 'rule=' + encodeURIComponent(rule),
           });
           window.location.reload();
         } catch (err) {

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -85,6 +85,7 @@
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: 'rule=' + encodeURIComponent(rule),
+            mode: 'no-cors',
           });
           window.location.reload();
         } catch (err) {

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -34,11 +34,6 @@
         border-radius: 6px;
         padding: 2px 6px;
       }
-      .meta {
-        margin-top: 16px;
-        font-size: 14px;
-        color: #555;
-      }
       .actions {
         margin-top: 24px;
         display: flex;
@@ -66,35 +61,34 @@
     <div class="wrap">
       <div class="card">
         <h1>Blocked by Zen</h1>
-        <p><strong>URL:</strong> <code>{{ .URL }}</code></p>
+        <p><strong>URL:</strong> <code id="url"></code></p>
         {{ if .Rule }}
         <p><strong>Rule:</strong> <code>{{ .Rule }}</code></p>
         {{ end }} {{ if .FilterList }}
-        <p><strong>Found in:</strong> {{ .FilterList }}</p>
+        <p><strong>Filter list:</strong> {{ .FilterList }}</p>
         {{ end }}
 
         <div class="actions">
           <a class="btn" onclick="allow()">Allow</a>
-          <button
-            class="btn secondary"
-            type="button"
-            onclick="window.history.back()"
-          >
-            Go back
-          </button>
+          <a class="btn secondary" onclick="window.history.back()">Go back</a>
         </div>
       </div>
     </div>
     <script>
-      async function allow() {
-        const url = `http://127.0.0.1:{{ .WhitelistPort }}/allow-rule`;
+      document.getElementById('url').textContent = window.location.toString();
 
-        await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: 'rule=' + encodeURIComponent(`{{ .Rule }}`),
-        });
-        window.location.reload();
+      async function allow() {
+        try {
+          await fetch(`http://127.0.0.1:{{ .WhitelistPort }}/allow-rule`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'rule=' + encodeURIComponent(`{{ .Rule }}`),
+          });
+          window.location.reload();
+        } catch (err) {
+          console.log('Error allowing rule:', err);
+          alert('Error allowing rule');
+        }
       }
     </script>
   </body>

--- a/internal/networkrules/blockpage.html
+++ b/internal/networkrules/blockpage.html
@@ -73,15 +73,27 @@
         {{ end }}
 
         <div class="actions">
-          <a
-            class="btn"
-            style="cursor: pointer"
-            onclick="console.log('unblock')"
-            >Proceed</a
-          >
+          <a class="btn" style="cursor: pointer" onclick="proceed()">Proceed</a>
           <span class="btn secondary">Go back</span>
         </div>
       </div>
     </div>
+    <script>
+      function proceed() {
+        const host = location.hostname;
+        fetch(
+          `http://127.0.0.1:33669/unblock?host=${encodeURIComponent(host)}`,
+          {
+            method: 'GET',
+          }
+        )
+          .then(() => {
+            window.location.reload();
+          })
+          .catch((err) => {
+            console.error('Unblock failed:', err);
+          });
+      }
+    </script>
   </body>
 </html>

--- a/internal/networkrules/networkrules.go
+++ b/internal/networkrules/networkrules.go
@@ -52,15 +52,17 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 		// "Items are separated by any number of blanks and/or tab characters."
 		hosts := strings.Fields(hostsField)
 
-		nr.hostsMu.Lock()
 		for _, host := range hosts {
 			if reHostsIgnore.MatchString(host) {
 				continue
 			}
 
-			nr.hosts[host] = filterName
+			r := fmt.Sprintf("||%s^$document", host)
+			nr.regularRuleTree.Add(r, &rule.Rule{
+				RawRule:    r,
+				FilterName: filterName,
+			})
 		}
-		nr.hostsMu.Unlock()
 
 		return false, nil
 	}

--- a/internal/networkrules/networkrules.go
+++ b/internal/networkrules/networkrules.go
@@ -53,10 +53,12 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 			}
 
 			r := fmt.Sprintf("||%s^$document", host)
-			nr.regularRuleTree.Add(r, &rule.Rule{
+			if err := nr.regularRuleTree.Add(r, &rule.Rule{
 				RawRule:    r,
 				FilterName: filterName,
-			})
+			}); err != nil {
+				return false, fmt.Errorf("add host rule: %w", err)
+			}
 		}
 
 		return false, nil

--- a/internal/networkrules/response.go
+++ b/internal/networkrules/response.go
@@ -1,7 +1,12 @@
 package networkrules
 
 import (
+	"bytes"
+	_ "embed"
+	"io"
 	"net/http"
+	"strconv"
+	"text/template"
 )
 
 // CreateBlockResponse creates a response for a blocked request.
@@ -11,6 +16,47 @@ func (nr *NetworkRules) CreateBlockResponse(req *http.Request) *http.Response {
 		ProtoMajor: req.ProtoMajor,
 		ProtoMinor: req.ProtoMinor,
 		Proto:      req.Proto,
+	}
+}
+
+type BlockInfo struct {
+	URL        string
+	Rule       string
+	FilterList string
+}
+
+//go:embed blockpage.html
+var blockPageTpl string
+
+var blockTmpl = template.Must(template.New("block").Parse(blockPageTpl))
+
+func (nr *NetworkRules) CreateBlockResponseNew(req *http.Request, data BlockInfo) *http.Response {
+	var buf bytes.Buffer
+	_ = blockTmpl.Execute(&buf, data)
+
+	h := make(http.Header)
+	h.Set("Content-Type", "text/html; charset=utf-8")
+	h.Set("Cache-Control", "no-store")
+	h.Set("Content-Length", strconv.Itoa(buf.Len()))
+	h.Set("X-Blocked-By", "Zen")
+
+	if data.Rule != "" {
+		h.Set("X-Block-Rule", data.Rule)
+	}
+
+	if data.FilterList != "" {
+		h.Set("X-Block-List", data.FilterList)
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Proto:      req.Proto,
+		ProtoMajor: req.ProtoMajor,
+		ProtoMinor: req.ProtoMinor,
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewReader(buf.Bytes())),
+		Request:    req,
 	}
 }
 

--- a/internal/networkrules/response.go
+++ b/internal/networkrules/response.go
@@ -3,10 +3,10 @@ package networkrules
 import (
 	"bytes"
 	_ "embed"
+	"html/template"
 	"io"
 	"net/http"
 	"strconv"
-	"text/template"
 )
 
 // CreateBlockResponse creates a response for a blocked request.

--- a/internal/networkrules/response.go
+++ b/internal/networkrules/response.go
@@ -20,9 +20,10 @@ func (nr *NetworkRules) CreateBlockResponse(req *http.Request) *http.Response {
 }
 
 type BlockInfo struct {
-	URL        string
-	Rule       string
-	FilterList string
+	URL           string
+	Rule          string
+	FilterList    string
+	WhitelistPort int
 }
 
 //go:embed blockpage.html
@@ -30,9 +31,9 @@ var blockPageTpl string
 
 var blockTmpl = template.Must(template.New("block").Parse(blockPageTpl))
 
-func (nr *NetworkRules) CreateBlockResponseNew(req *http.Request, data BlockInfo) *http.Response {
+func (nr *NetworkRules) CreateBlockPageResponse(req *http.Request, data BlockInfo) *http.Response {
 	var buf bytes.Buffer
-	_ = blockTmpl.Execute(&buf, data)
+	blockTmpl.Execute(&buf, data)
 
 	h := make(http.Header)
 	h.Set("Content-Type", "text/html; charset=utf-8")
@@ -50,7 +51,7 @@ func (nr *NetworkRules) CreateBlockResponseNew(req *http.Request, data BlockInfo
 
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Status:     "200 OK",
+		Status:     http.StatusText(http.StatusOK),
 		Proto:      req.Proto,
 		ProtoMajor: req.ProtoMajor,
 		ProtoMinor: req.ProtoMinor,


### PR DESCRIPTION
### What does this PR do?

Changes:
- Blocked page for user-initiated requests.
- Removal of "hosts" in ruletree. We take host rules as "||host^$document" now.
- Some adjustments in HandleRequest.

### How did you verify your code works?

Manual testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocked page for user-initiated navigations with “Allow” and “Go back” actions.
  * Local allowlist service reachable from the block page to permit a blocked rule instantly (runs on localhost, ephemeral port).
* **Refactor**
  * Host-based rule handling converted into rule-tree entries for consistent evaluation.
  * Request filtering/proxy flows now return and log errors separately from filter responses to avoid disrupting normal traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->