### PR TITLE
Change MyRules: add line numbering, split logic and JSX and fix empty line deletion

### DIFF
--- a/frontend/src/MyRules/editor/Editor.tsx
+++ b/frontend/src/MyRules/editor/Editor.tsx
@@ -1,0 +1,64 @@
+import { TextArea } from '@blueprintjs/core';
+import React, { useMemo, useRef, useCallback } from 'react';
+import { useWraps } from './useWraps';
+
+type Props = {
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  onChange: (next: string) => void;
+  lines: string[];
+};
+
+export function MyRulesEditor({ value, placeholder, disabled, onChange, lines }: Props) {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const lineNumbersRef = useRef<HTMLDivElement>(null);
+  const mirrorRef = useRef<HTMLDivElement>(null);
+
+  const { wraps } = useWraps({ value, lines, textAreaRef, mirrorRef });
+
+  const syncScroll = useCallback(() => {
+    if (lineNumbersRef.current && textAreaRef.current) {
+      lineNumbersRef.current.scrollTop = textAreaRef.current.scrollTop;
+    }
+  }, []);
+
+  const lineNumberItems = useMemo(() => {
+    const items: React.ReactNode[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const w = wraps[i] ?? 1;
+      items.push(
+        <div key={`ln-${i}-0`} className="line-number">
+          {i + 1}
+        </div>,
+      );
+      for (let k = 1; k < w; k++) {
+        items.push(<div key={`ln-${i}-${k}`} className="line-number line-number--cont" />);
+      }
+    }
+    return items;
+  }, [lines.length, wraps]);
+
+  return (
+    <div className="my-rules__editor">
+      <div ref={lineNumbersRef} className="my-rules__line-numbers">
+        {lineNumberItems}
+      </div>
+
+      <TextArea
+        inputRef={textAreaRef}
+        fill
+        placeholder={placeholder}
+        className="my-rules__textarea"
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={syncScroll}
+      />
+
+      <div ref={mirrorRef} className="my-rules__mirror" aria-hidden>
+        <div className="my-rules__mirror-lines" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/MyRules/editor/useWraps.ts
+++ b/frontend/src/MyRules/editor/useWraps.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+
+type Args = {
+  value: string;
+  lines: string[];
+  textAreaRef: React.RefObject<HTMLTextAreaElement>;
+  mirrorRef: React.RefObject<HTMLDivElement>;
+};
+
+export function useWraps({ value, lines, textAreaRef, mirrorRef }: Args) {
+  const [wraps, setWraps] = useState<number[]>([]);
+
+  const computeLineHeightPx = useCallback((): number => {
+    const ta = textAreaRef.current;
+    if (!ta) return 20;
+    const cs = window.getComputedStyle(ta);
+    const lh = cs.lineHeight;
+    if (!lh || lh === 'normal') {
+      const fs = parseFloat(cs.fontSize || '16');
+      return Math.round(fs * 1.2);
+    }
+    return Math.round(parseFloat(lh));
+  }, [textAreaRef]);
+
+  const recalcWraps = useCallback(() => {
+    const ta = textAreaRef.current;
+    const mirror = mirrorRef.current;
+    if (!ta || !mirror) return;
+
+    const cs = window.getComputedStyle(ta);
+    const innerWidth = ta.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+
+    // Важно: повторяем те же параметры, что у textarea
+    mirror.style.width = `${Math.max(0, innerWidth)}px`;
+    mirror.style.fontFamily = cs.fontFamily;
+    mirror.style.fontSize = cs.fontSize;
+    mirror.style.lineHeight = cs.lineHeight;
+    mirror.style.paddingTop = cs.paddingTop;
+    mirror.style.paddingBottom = cs.paddingBottom;
+
+    const mirrorLines = mirror.querySelector('.my-rules__mirror-lines') as HTMLDivElement | null;
+    if (!mirrorLines) return;
+    mirrorLines.innerHTML = '';
+
+    const lineHeightPx = computeLineHeightPx();
+
+    for (const ln of lines) {
+      const lineDiv = document.createElement('div');
+      lineDiv.className = 'my-rules__mirror-line';
+      lineDiv.textContent = ln.length > 0 ? ln : ' ';
+      mirrorLines.appendChild(lineDiv);
+    }
+
+    const newWraps: number[] = [];
+    const children = mirrorLines.children;
+    for (let i = 0; i < children.length; i++) {
+      const el = children[i] as HTMLElement;
+      const h = el.scrollHeight;
+      const wrapsForLine = Math.max(1, Math.round(h / lineHeightPx));
+      newWraps.push(wrapsForLine);
+    }
+
+    setWraps(newWraps);
+  }, [computeLineHeightPx, lines, textAreaRef, mirrorRef]);
+
+  // Пересчёт при изменении текста
+  useLayoutEffect(() => {
+    recalcWraps();
+  }, [value, recalcWraps]);
+
+  // Пересчёт при ресайзе textarea
+  useEffect(() => {
+    const ta = textAreaRef.current;
+    if (!ta) return;
+    const ro = new ResizeObserver(() => recalcWraps());
+    ro.observe(ta);
+    return () => ro.disconnect();
+  }, [recalcWraps, textAreaRef]);
+
+  return { wraps, recalcWraps };
+}

--- a/frontend/src/MyRules/index.css
+++ b/frontend/src/MyRules/index.css
@@ -16,13 +16,18 @@
 }
 
 .my-rules__editor {
-  position: relative; /* для зеркала */
+  position: relative;
   display: flex;
   height: 100%;
   max-height: 100%;
   overflow: hidden;
   align-items: stretch;
   min-height: 0;
+  border-radius: 1px;
+}
+
+.my-rules__editor:focus-within {
+  outline: 1px solid #3374c0;
 }
 
 .my-rules__line-numbers {

--- a/frontend/src/MyRules/index.css
+++ b/frontend/src/MyRules/index.css
@@ -2,19 +2,81 @@
   display: flex;
   flex-direction: column;
   height: calc(100% - 8px);
+  min-height: 0;
 }
 
 .my-rules__help-button {
   margin-bottom: 8px;
 }
 
-.my-rules__textarea {
-  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-  font-size: 0.9em;
-  height: 100% !important;
-}
-
 .my-rules__tooltip {
   height: 100%;
   width: 100%;
+  min-height: 0;
+}
+
+.my-rules__editor {
+  position: relative; /* для зеркала */
+  display: flex;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+  align-items: stretch;
+  min-height: 0;
+}
+
+.my-rules__line-numbers {
+  flex: 0 0 2em;
+  width: 2em;
+  color: #858585;
+  text-align: right;
+  font-size: 0.9em;
+  background-color: white;
+  padding: 0.9em 0;
+  user-select: none;
+  line-height: 1.4em;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.line-number {
+  height: 1.4em;
+  line-height: 1.4em;
+}
+
+.my-rules__textarea {
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-gutter: stable;
+
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  font-size: 0.9em !important;
+  line-height: 1.4em !important;
+  resize: none;
+  padding: 4px 6px;
+}
+
+.my-rules__textarea.bp4-input,
+.my-rules__textarea.bp5-input {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.my-rules__mirror {
+  position: absolute;
+  top: 0;
+  left: -99999px;
+  visibility: hidden;
+  pointer-events: none;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.my-rules__mirror-line {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }

--- a/frontend/src/MyRules/index.tsx
+++ b/frontend/src/MyRules/index.tsx
@@ -21,12 +21,7 @@ export function MyRules() {
   });
 
   const setFilters = useDebouncedCallback(async (rules: string) => {
-    await SetMyRules(
-      rules
-        .split('\n')
-        .map((f) => f.trim())
-        .filter((f) => f.length > 0),
-    );
+    await SetMyRules(rules.replace(/\r\n/g, '\n').split('\n'));
   }, 500);
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

This PR changes the implementation of the **MyRules** editor so that it behaves more like a code editor:

- Added line numbers for each line in the text area.  
  This was achieved by creating a container with two blocks: one for line numbers and one for the text area itself, with logic to sync them.  
- Implemented correct alignment of line numbers for long wrapped lines.  
  A custom `useWraps` hook calculates how many visual lines each text line takes, based on text width and the textarea size.  
- Split the logic into separate files:  
  - `Editor` – contains the editor rendering logic.  
  - `useWraps` – isolates wrapping calculations from the backend interaction logic.  
- Fixed a bug that caused empty lines to be deleted when sending rules to the backend.  
- Added `outline` and `border-radius` to the editor container to visually resemble the original textarea when focused.

<img width="401" height="641" alt="image" src="https://github.com/user-attachments/assets/b6b7e831-29aa-4eea-84a4-8923a4a6bfc0" />

This closes the following issue:  
**Add line numbers in "My Rules" text area #437**

### How did you verify your code works?

- Manually tested typing, editing, and deleting rules in the editor.  
- Verified that line numbers stay aligned even with long wrapped lines.  
- Ensured empty lines are preserved when sending rules to the backend.  
- Checked that the editor styling matches the original textarea behavior (focus outline and border radius).  

### What are the relevant issues?

Closes [#437] (https://github.com/ZenPrivacy/zen-desktop/issues/437)