### PR TITLE
Refactor CSS injectors to patch CSP headers and use html/template

### DIFF
--- a/internal/cosmetic/injector.go
+++ b/internal/cosmetic/injector.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"html/template"
 	"log"
 	"net/http"
 	"regexp"
 	"strings"
 
+	"github.com/ZenPrivacy/zen-desktop/internal/csp"
 	"github.com/ZenPrivacy/zen-desktop/internal/hostmatch"
 	"github.com/ZenPrivacy/zen-desktop/internal/httprewrite"
 	"github.com/ZenPrivacy/zen-desktop/internal/logger"
@@ -19,8 +21,7 @@ var (
 	primaryRuleRegex   = regexp.MustCompile(`(.*?)##(.*)`)
 	exceptionRuleRegex = regexp.MustCompile(`(.*?)#@#(.+)`)
 
-	injectionStart = []byte("<style>")
-	injectionEnd   = []byte("</style>")
+	injectionTmpl = template.Must(template.New("cosmetic").Parse(`<style{{if .Nonce}} nonce="{{.Nonce}}"{{end}}>{{.Rules}}</style>`))
 )
 
 type store interface {
@@ -69,16 +70,25 @@ func (inj *Injector) Inject(req *http.Request, res *http.Response) error {
 		return nil
 	}
 
-	var ruleInjection bytes.Buffer
-	ruleInjection.Write(injectionStart)
-	css := generateBatchedCSS(selectors)
-	ruleInjection.WriteString(css)
-	ruleInjection.Write(injectionEnd)
+	nonce := csp.PatchHeaders(res.Header, csp.InlineStyle)
+	stylesheet := generateBatchedCSS(selectors)
+
+	var injection bytes.Buffer
+	err := injectionTmpl.Execute(&injection, struct {
+		Nonce string
+		Rules template.CSS
+	}{
+		Nonce: nonce,
+		Rules: template.CSS(stylesheet), // #nosec G203 -- Rules are sanitized during addition.
+	})
+	if err != nil {
+		return fmt.Errorf("execute template: %v", err)
+	}
 
 	// Why append and not prepend?
 	// When multiple CSS rules define an !important property, conflicts are resolved first by specificity and then by the order of the CSS declarations.
 	// Appending ensures our rules take precedence.
-	if err := httprewrite.AppendHTMLHeadContents(res, ruleInjection.Bytes()); err != nil {
+	if err := httprewrite.AppendHTMLHeadContents(res, injection.Bytes()); err != nil {
 		return fmt.Errorf("append head contents: %w", err)
 	}
 

--- a/internal/cosmetic/injector_test.go
+++ b/internal/cosmetic/injector_test.go
@@ -1,0 +1,114 @@
+package cosmetic
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+func TestInjector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nonce in the <style> attribute matches the Content-Security-Policy header", func(t *testing.T) {
+		t.Parallel()
+
+		const initialHTML = "<!doctype html><html><head><meta charset='utf-8'></head><body><h1>hi</h1></body></html>"
+		inj := NewInjector()
+		if err := inj.AddRule("example.com##.ads"); err != nil {
+			t.Fatalf("AddRule: %v", err)
+		}
+
+		req := &http.Request{
+			URL: &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+		}
+
+		res := &http.Response{
+			StatusCode: 200,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte(initialHTML))),
+		}
+		res.Header.Set("Content-Security-Policy", "default-src 'none'; style-src 'none'")
+		res.Header.Set("Content-Type", "text/html; charset=utf-8")
+
+		if err := inj.Inject(req, res); err != nil {
+			t.Fatalf("Inject: %v", err)
+		}
+
+		finalBody, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("read injected body: %v", err)
+		}
+
+		doc, err := html.Parse(bytes.NewReader(finalBody))
+		if err != nil {
+			t.Fatalf("parse injected HTML: %v", err)
+		}
+
+		head := findNode(doc, func(n *html.Node) bool { return n.Type == html.ElementNode && n.Data == "head" })
+		if head == nil {
+			t.Fatal("<head> not found in injected HTML")
+		}
+
+		style := findNode(head, func(n *html.Node) bool { return n.Type == html.ElementNode && n.Data == "style" })
+		if style == nil {
+			t.Fatal("injected <style> not found in <head>")
+		}
+
+		styleNonce := getAttr(style, "nonce")
+		if styleNonce == "" {
+			t.Fatal("injected <style> missing nonce attribute")
+		}
+
+		cspHeader := res.Header.Get("Content-Security-Policy")
+		if cspHeader == "" {
+			t.Fatal("CSP header not set")
+		}
+
+		nonce := extractNonceFromCSP(cspHeader)
+		if nonce == "" {
+			t.Fatalf("nonce not found in CSP header: %q", cspHeader)
+		}
+
+		if nonce != styleNonce {
+			t.Fatalf("nonce mismatch: CSP=%q style=%q", nonce, styleNonce)
+		}
+	})
+}
+
+func findNode(n *html.Node, pred func(*html.Node) bool) *html.Node {
+	if n == nil {
+		return nil
+	}
+	if pred(n) {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if found := findNode(c, pred); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func getAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func extractNonceFromCSP(csp string) string {
+	re := regexp.MustCompile(`'nonce-([A-Za-z0-9+/_=-]+)'`)
+	m := re.FindStringSubmatch(csp)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}

--- a/internal/cssrule/injector_test.go
+++ b/internal/cssrule/injector_test.go
@@ -1,0 +1,114 @@
+package cssrule
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+func TestInjector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nonce in the <style> attribute matches the Content-Security-Policy header", func(t *testing.T) {
+		t.Parallel()
+
+		const initialHTML = "<!doctype html><html><head><meta charset='utf-8'></head><body><h1>hi</h1></body></html>"
+		inj := NewInjector()
+		if err := inj.AddRule("example.com#$#.ads{visibility:none!important;}"); err != nil {
+			t.Fatalf("AddRule: %v", err)
+		}
+
+		req := &http.Request{
+			URL: &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+		}
+
+		res := &http.Response{
+			StatusCode: 200,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte(initialHTML))),
+		}
+		res.Header.Set("Content-Security-Policy", "default-src 'none'; style-src 'none'")
+		res.Header.Set("Content-Type", "text/html; charset=utf-8")
+
+		if err := inj.Inject(req, res); err != nil {
+			t.Fatalf("Inject: %v", err)
+		}
+
+		finalBody, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("read injected body: %v", err)
+		}
+
+		doc, err := html.Parse(bytes.NewReader(finalBody))
+		if err != nil {
+			t.Fatalf("parse injected HTML: %v", err)
+		}
+
+		head := findNode(doc, func(n *html.Node) bool { return n.Type == html.ElementNode && n.Data == "head" })
+		if head == nil {
+			t.Fatal("<head> not found in injected HTML")
+		}
+
+		style := findNode(head, func(n *html.Node) bool { return n.Type == html.ElementNode && n.Data == "style" })
+		if style == nil {
+			t.Fatal("injected <style> not found in <head>")
+		}
+
+		styleNonce := getAttr(style, "nonce")
+		if styleNonce == "" {
+			t.Fatal("injected <style> missing nonce attribute")
+		}
+
+		cspHeader := res.Header.Get("Content-Security-Policy")
+		if cspHeader == "" {
+			t.Fatal("CSP header not set")
+		}
+
+		nonce := extractNonceFromCSP(cspHeader)
+		if nonce == "" {
+			t.Fatalf("nonce not found in CSP header: %q", cspHeader)
+		}
+
+		if nonce != styleNonce {
+			t.Fatalf("nonce mismatch: CSP=%q style=%q", nonce, styleNonce)
+		}
+	})
+}
+
+func findNode(n *html.Node, pred func(*html.Node) bool) *html.Node {
+	if n == nil {
+		return nil
+	}
+	if pred(n) {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if found := findNode(c, pred); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func getAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func extractNonceFromCSP(csp string) string {
+	re := regexp.MustCompile(`'nonce-([A-Za-z0-9+/_=-]+)'`)
+	m := re.FindStringSubmatch(csp)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}


### PR DESCRIPTION
### What does this PR do?
Refactors `cosmetic` and `cssrule` injectors to:
1. Perform CSP modification via `csp.PatchHeaders`
2. Use `html/template`-based injections 

### How did you verify your code works?
- New unit tests covering CSP injection
- Manual testing

### What are the relevant issues?
closes #451 
