### PR TITLE
Optimize ruletree node memory usage

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -36,6 +36,7 @@ type networkRules interface {
 	CreateBlockResponse(req *http.Request) *http.Response
 	CreateRedirectResponse(req *http.Request, to string) *http.Response
 	CreateBlockPageResponse(req *http.Request, appliedRules []rule.Rule, whitelistPort int) (*http.Response, error)
+	Compact() int
 }
 
 // config provides filter configuration.
@@ -194,6 +195,11 @@ func (f *Filter) init() {
 
 	if len(myRules) > 0 {
 		log.Printf("filter initialization: added %d rules and %d exceptions from %q", ruleCount, exceptionCount, filterName)
+	}
+
+	reds := f.networkRules.Compact()
+	if reds > 0 {
+		log.Printf("filter initialization: reduced slice capacity by %d", reds)
 	}
 }
 

--- a/internal/networkrules/networkrules.go
+++ b/internal/networkrules/networkrules.go
@@ -34,6 +34,14 @@ func NewNetworkRules() *NetworkRules {
 	}
 }
 
+// Compact shrinks internal slice capacities in both rule trees to reduce memory usage.
+// It returns the total capacity reductions (sum of cap - len deltas) across both trees.
+func (nr *NetworkRules) Compact() int {
+	regularReductions := nr.regularRuleTree.Compact()
+	exceptionReductions := nr.exceptionRuleTree.Compact()
+	return regularReductions + exceptionReductions
+}
+
 func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isException bool, err error) {
 	if matches := reHosts.FindStringSubmatch(rawRule); matches != nil {
 		hostsField := matches[1]

--- a/internal/ruletree/node.go
+++ b/internal/ruletree/node.go
@@ -6,8 +6,15 @@ import (
 	"sync"
 )
 
+// Constants for bit manipulation (4 bits for kind, 28 bits for tokenID).
+const (
+	tokenIDMask uint32 = (1 << 28) - 1
+	kindMask    uint32 = 0xF
+	kindShift          = 28
+)
+
 // nodeKind defines the type of a node in the trie.
-type nodeKind int8
+type nodeKind uint8
 
 const (
 	nodeKindExactMatch  nodeKind = iota
@@ -23,9 +30,34 @@ const (
 // It comprises the node's kind and the ID of the token that the node represents.
 // The token is included only for nodes of the type 'nodeKindExactMatch'.
 // Nodes of other kinds represent the roots of subtrees without including a token.
+// The structure is optimized to use a single uint32 for storage, with 4 bits allocated for the kind
+// and 28 bits for the token ID.
 type nodeKey struct {
-	kind    nodeKind
-	tokenID uint32
+	packedData uint32
+}
+
+// newNodeKey creates a new, optimized nodeKey.
+func newNodeKey(kind nodeKind, tokenID uint32) nodeKey {
+	if uint32(kind) > kindMask {
+		panic("kind exceeds 4-bit limit")
+	}
+
+	if tokenID > tokenIDMask {
+		panic("tokenID exceeds 28-bit limit")
+	}
+
+	packed := (uint32(kind) << kindShift) | tokenID
+	return nodeKey{packedData: packed}
+}
+
+// Kind extracts the `nodeKind` from packedData.
+func (nk nodeKey) Kind() nodeKind {
+	return nodeKind((nk.packedData >> kindShift) & kindMask) //nolint:gosec
+}
+
+// TokenID extracts the `tokenID` from packedData.
+func (nk nodeKey) TokenID() uint32 {
+	return nk.packedData & tokenIDMask
 }
 
 // arrNode is a node in the trie that is stored in an array.
@@ -127,16 +159,16 @@ func (n *node[T]) TraverseFindMatchingRulesReq(req *http.Request, tokens []strin
 	if len(tokens) == 0 {
 		// End of an address is a valid separator, see:
 		// https://adguard.com/kb/general/ad-filtering/create-own-filters/#basic-rules-special-characters.
-		rules = append(rules, n.FindChild(nodeKey{kind: nodeKindSeparator}).TraverseFindMatchingRulesReq(req, tokens, shouldUseNode, interner)...)
+		rules = append(rules, n.FindChild(newNodeKey(nodeKindSeparator, 0)).TraverseFindMatchingRulesReq(req, tokens, shouldUseNode, interner)...)
 		return rules
 	}
 	if reSeparator.MatchString(tokens[0]) {
-		rules = append(rules, n.FindChild(nodeKey{kind: nodeKindSeparator}).TraverseFindMatchingRulesReq(req, tokens[1:], shouldUseNode, interner)...)
+		rules = append(rules, n.FindChild(newNodeKey(nodeKindSeparator, 0)).TraverseFindMatchingRulesReq(req, tokens[1:], shouldUseNode, interner)...)
 	}
-	rules = append(rules, n.FindChild(nodeKey{kind: nodeKindWildcard}).TraverseFindMatchingRulesReq(req, tokens[1:], shouldUseNode, interner)...)
+	rules = append(rules, n.FindChild(newNodeKey(nodeKindWildcard, 0)).TraverseFindMatchingRulesReq(req, tokens[1:], shouldUseNode, interner)...)
 
 	id := interner.Intern(tokens[0])
-	rules = append(rules, n.FindChild(nodeKey{kind: nodeKindExactMatch, tokenID: id}).TraverseFindMatchingRulesReq(req, tokens[1:],
+	rules = append(rules, n.FindChild(newNodeKey(nodeKindExactMatch, id)).TraverseFindMatchingRulesReq(req, tokens[1:],
 		shouldUseNode, interner)...)
 
 	return rules
@@ -161,16 +193,16 @@ func (n *node[T]) TraverseFindMatchingRulesRes(res *http.Response, tokens []stri
 	if len(tokens) == 0 {
 		// End of an address is a valid separator, see:
 		// https://adguard.com/kb/general/ad-filtering/create-own-filters/#basic-rules-special-characters.
-		rules = append(rules, n.FindChild(nodeKey{kind: nodeKindSeparator}).TraverseFindMatchingRulesRes(res, tokens, shouldUseNode, interner)...)
+		rules = append(rules, n.FindChild(newNodeKey(nodeKindSeparator, 0)).TraverseFindMatchingRulesRes(res, tokens, shouldUseNode, interner)...)
 		return rules
 	}
 	if reSeparator.MatchString(tokens[0]) {
-		rules = append(rules, n.FindChild(nodeKey{kind: nodeKindSeparator}).TraverseFindMatchingRulesRes(res, tokens[1:], shouldUseNode, interner)...)
+		rules = append(rules, n.FindChild(newNodeKey(nodeKindSeparator, 0)).TraverseFindMatchingRulesRes(res, tokens[1:], shouldUseNode, interner)...)
 	}
-	rules = append(rules, n.FindChild(nodeKey{kind: nodeKindWildcard}).TraverseFindMatchingRulesRes(res, tokens[1:], shouldUseNode, interner)...)
+	rules = append(rules, n.FindChild(newNodeKey(nodeKindWildcard, 0)).TraverseFindMatchingRulesRes(res, tokens[1:], shouldUseNode, interner)...)
 
 	id := interner.Intern(tokens[0])
-	rules = append(rules, n.FindChild(nodeKey{kind: nodeKindExactMatch, tokenID: id}).TraverseFindMatchingRulesRes(res, tokens[1:],
+	rules = append(rules, n.FindChild(newNodeKey(nodeKindExactMatch, id)).TraverseFindMatchingRulesRes(res, tokens[1:],
 		shouldUseNode, interner)...)
 
 	return rules

--- a/internal/ruletree/ruletree.go
+++ b/internal/ruletree/ruletree.go
@@ -102,9 +102,9 @@ func (rt *RuleTree[T]) Add(urlPattern string, data T) error {
 		}
 	}
 
-	node.dataMu.Lock()
+	node.mu.Lock()
 	node.data = append(node.data, data)
-	node.dataMu.Unlock()
+	node.mu.Unlock()
 
 	return nil
 }

--- a/internal/ruletree/ruletree.go
+++ b/internal/ruletree/ruletree.go
@@ -81,7 +81,7 @@ func (rt *RuleTree[T]) Add(urlPattern string, data T) error {
 	if rootKeyKind == nodeKindExactMatch {
 		node = &rt.root
 	} else {
-		node = rt.root.findOrAddChild(nodeKey{kind: rootKeyKind})
+		node = rt.root.findOrAddChild(newNodeKey(rootKeyKind, 0))
 	}
 
 	tokenIDs := make([]uint32, 0, len(rawTokens))
@@ -92,13 +92,13 @@ func (rt *RuleTree[T]) Add(urlPattern string, data T) error {
 	for i, raw := range rawTokens {
 		switch raw {
 		case "^":
-			node = node.findOrAddChild(nodeKey{kind: nodeKindSeparator})
+			node = node.findOrAddChild(newNodeKey(nodeKindSeparator, 0))
 		case "*":
-			node = node.findOrAddChild(nodeKey{kind: nodeKindWildcard})
+			node = node.findOrAddChild(newNodeKey(nodeKindWildcard, 0))
 		default:
 			// exact‐match: use the interned ID
 			id := tokenIDs[i]
-			node = node.findOrAddChild(nodeKey{kind: nodeKindExactMatch, tokenID: id})
+			node = node.findOrAddChild(newNodeKey(nodeKindExactMatch, id))
 		}
 	}
 
@@ -124,12 +124,12 @@ func (rt *RuleTree[T]) FindMatchingRulesReq(req *http.Request) (data []T) {
 	// generic rules -> address root -> hostname root -> domain -> etc.
 
 	// generic rules
-	if genericNode := rt.root.FindChild(nodeKey{kind: nodeKindGeneric}); genericNode != nil {
+	if genericNode := rt.root.FindChild(newNodeKey(nodeKindGeneric, 0)); genericNode != nil {
 		data = append(data, genericNode.FindMatchingRulesReq(req)...)
 	}
 
 	// address root
-	data = append(data, rt.root.FindChild(nodeKey{kind: nodeKindAddressRoot}).TraverseFindMatchingRulesReq(req, tokens, func(_ *node[T], t []string) bool {
+	data = append(data, rt.root.FindChild(newNodeKey(nodeKindAddressRoot, 0)).TraverseFindMatchingRulesReq(req, tokens, func(_ *node[T], t []string) bool {
 		// address root rules have to match the entire URL
 		// TODO: look into whether we can match the rule if the remaining tokens only contain the query
 		return len(t) == 0
@@ -148,7 +148,7 @@ func (rt *RuleTree[T]) FindMatchingRulesReq(req *http.Request) (data []T) {
 			break
 		}
 		if tokens[0] != "." {
-			data = append(data, rt.root.FindChild(nodeKey{kind: nodeKindDomain}).TraverseFindMatchingRulesReq(req, tokens, nil, rt.interner)...)
+			data = append(data, rt.root.FindChild(newNodeKey(nodeKindDomain, 0)).TraverseFindMatchingRulesReq(req, tokens, nil, rt.interner)...)
 		}
 		data = append(data, rt.root.TraverseFindMatchingRulesReq(req, tokens, nil, rt.interner)...)
 		tokens = tokens[1:]
@@ -179,12 +179,12 @@ func (rt *RuleTree[T]) FindMatchingRulesRes(req *http.Request, res *http.Respons
 	// generic rules -> address root -> hostname root -> domain -> etc.
 
 	// generic rules
-	if genericNode := rt.root.FindChild(nodeKey{kind: nodeKindGeneric}); genericNode != nil {
+	if genericNode := rt.root.FindChild(newNodeKey(nodeKindGeneric, 0)); genericNode != nil {
 		rules = append(rules, genericNode.FindMatchingRulesRes(res)...)
 	}
 
 	// address root
-	rules = append(rules, rt.root.FindChild(nodeKey{kind: nodeKindAddressRoot}).TraverseFindMatchingRulesRes(res, tokens, func(_ *node[T], t []string) bool {
+	rules = append(rules, rt.root.FindChild(newNodeKey(nodeKindAddressRoot, 0)).TraverseFindMatchingRulesRes(res, tokens, func(_ *node[T], t []string) bool {
 		return len(t) == 0
 	}, rt.interner)...)
 
@@ -201,7 +201,7 @@ func (rt *RuleTree[T]) FindMatchingRulesRes(req *http.Request, res *http.Respons
 			break
 		}
 		if tokens[0] != "." {
-			rules = append(rules, rt.root.FindChild(nodeKey{kind: nodeKindDomain}).TraverseFindMatchingRulesRes(res, tokens, nil, rt.interner)...)
+			rules = append(rules, rt.root.FindChild(newNodeKey(nodeKindDomain, 0)).TraverseFindMatchingRulesRes(res, tokens, nil, rt.interner)...)
 		}
 		rules = append(rules, rt.root.TraverseFindMatchingRulesRes(res, tokens, nil, rt.interner)...)
 		tokens = tokens[1:]

--- a/internal/ruletree/slices.go
+++ b/internal/ruletree/slices.go
@@ -1,0 +1,17 @@
+package ruletree
+
+// TrimSlice shrinks the capacity of a slice to its length and
+// returns the new slice and number of capacity reductions made.
+func TrimSlice[T any](s []T) ([]T, int) {
+	if s == nil {
+		return nil, 0
+	}
+
+	if len(s) == cap(s) {
+		return s, 0
+	}
+
+	newSlice := make([]T, len(s))
+	copy(newSlice, s)
+	return newSlice, cap(s) - len(s)
+}


### PR DESCRIPTION
```
Optimize ruletree node memory usage

Reduce nodeKey struct size from 16 to 8 bytes by using a single type for kind
and tokenID. This saves memory and improves cache locality. I am making an
assumption that we will not have more than 2^4=16 kinds of nodes and not more than
2^28=268435456 unique tokens.
```

---

```
Use single mutex to protect node data and children

Each node in ruletree have two RWMutex structures that is 48 bytes per node.
This change uses a single Mutex to protect both children and data
structures which uses only 8 bytes of memory. This is a trade-off
between concurrency and memory usage, but in practice the contention
is low and the memory savings are significant.
```

---

```
Compact rule tree nodes to save memory

Once filter is done loading rules, we can compact the rule tree nodes to
save memory. Support is added to the filter only, server can still break
down rules into smaller chunks.
```

This is just completely random, I just installed the app, liked it, saw the issue about memory consumption and this came to my mind. It really is quite demanding, I see 700 MB shortly after few hours of use this is not ideal that is more than my browser.

The third patch only uses the method for filter, I am not sure what `server.go` actually is for as I am not familiar with the architecture. I am assuming that is some "dynamic" rule adding (when user changes config?) but it should work just fine. When user adds some rules slices get reallocated but then after app restart it will be compacted I guess.

_Warning: I did not test anything, this is completely blind code. I have plenty of experience with OS programming and Go, however, I have no idea how to build the project using those JS tools._