### PR TITLE
Implement proper classification of extended CSS rules masquerading as cosmetic rules

### DIFF
--- a/internal/cosmetic/cosmetic.go
+++ b/internal/cosmetic/cosmetic.go
@@ -1,0 +1,24 @@
+package cosmetic
+
+import (
+	"regexp"
+
+	"github.com/ZenPrivacy/zen-desktop/internal/extendedcss"
+)
+
+var (
+	ruleRegex = regexp.MustCompile(`^.*#@?#(.+)$`)
+)
+
+// IsRule returns true if the given string is a cosmetic rule.
+func IsRule(s string) bool {
+	match := ruleRegex.FindStringSubmatch(s)
+	if match == nil {
+		return false
+	}
+
+	body := match[1]
+	// uBlock Origin uses the same syntax for cosmetic and extended CSS rules,
+	// so we return false if the rule body contains any extended pseudo-classes.
+	return !extendedcss.ExtPseudoClassRegex.MatchString(body)
+}

--- a/internal/cosmetic/injector.go
+++ b/internal/cosmetic/injector.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	RuleRegex          = regexp.MustCompile(`.*#@?#.+`)
 	primaryRuleRegex   = regexp.MustCompile(`(.*?)##(.*)`)
 	exceptionRuleRegex = regexp.MustCompile(`(.*?)#@#(.+)`)
 

--- a/internal/extendedcss/extendedcss.go
+++ b/internal/extendedcss/extendedcss.go
@@ -1,0 +1,12 @@
+package extendedcss
+
+import "regexp"
+
+var (
+	ruleRegex = regexp.MustCompile(`^.+#@?\??#.+$`)
+)
+
+// IsRule returns true if the given string is an extended CSS rule.
+func IsRule(s string) bool {
+	return ruleRegex.MatchString(s)
+}

--- a/internal/extendedcss/extendedcss.go
+++ b/internal/extendedcss/extendedcss.go
@@ -3,6 +3,9 @@ package extendedcss
 import "regexp"
 
 var (
+	// ExtPseudoClassRegex matches extended pseudo-classes.
+	ExtPseudoClassRegex = regexp.MustCompile(`:(?:has-text|contains|matches-attr|matches-css(?:-before|-after)?|matches-media|matches-path|matches-prop(?:erty)?|min-text-length|others|upward|xpath|nth-ancestor|-abp-(?:contains|has))`)
+
 	ruleRegex = regexp.MustCompile(`^.+#@?\??#.+$`)
 )
 

--- a/internal/extendedcss/injector.go
+++ b/internal/extendedcss/injector.go
@@ -18,11 +18,11 @@ import (
 )
 
 var (
-	// RuleRegex matches extended CSS rules.
-	RuleRegex = regexp.MustCompile(`.+?#@?\?#.+$`)
+	// ExtPseudoClassRegex matches extended pseudo-classes.
+	ExtPseudoClassRegex = regexp.MustCompile(`:(?:has-text|contains|matches-attr|matches-css(?:-before|-after)?|matches-media|matches-path|matches-prop(?:erty)?|min-text-length|others|upward|xpath|nth-ancestor|-abp-(?:contains|has))`)
 
-	primaryRuleRegex   = regexp.MustCompile(`(.+?)#\?#(.+)`)
-	exceptionRuleRegex = regexp.MustCompile(`(.+?)#@\?#(.+)`)
+	primaryRuleRegex   = regexp.MustCompile(`(.+?)#\??#(.+)`)
+	exceptionRuleRegex = regexp.MustCompile(`(.+?)#@\??#(.+)`)
 
 	//go:embed bundle.js
 	defaultExtendedCSSBundle []byte

--- a/internal/extendedcss/injector.go
+++ b/internal/extendedcss/injector.go
@@ -18,9 +18,6 @@ import (
 )
 
 var (
-	// ExtPseudoClassRegex matches extended pseudo-classes.
-	ExtPseudoClassRegex = regexp.MustCompile(`:(?:has-text|contains|matches-attr|matches-css(?:-before|-after)?|matches-media|matches-path|matches-prop(?:erty)?|min-text-length|others|upward|xpath|nth-ancestor|-abp-(?:contains|has))`)
-
 	primaryRuleRegex   = regexp.MustCompile(`(.+?)#\??#(.+)`)
 	exceptionRuleRegex = regexp.MustCompile(`(.+?)#@\??#(.+)`)
 


### PR DESCRIPTION
### What does this PR do?
Adds a check that ensures cosmetic rules containing an extended CSS pseudo-class get rerouted into the extended CSS injector. This improves compatibility with uBO filter lists, which do not use the special syntax for extended CSS rules: [example](https://github.com/uBlockOrigin/uAssets/blob/48ecf0f372f057ce10c0d4a8bd5aac9beae1bde8/filters/filters-general.txt#L420).

### How did you verify your code works?
Manual testing.

### What are the relevant issues?
