### PR TITLE
Pin Windows build runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
 
   build-windows:
     name: Build Windows (${{ matrix.arch }})
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         arch: [amd64, arm64]


### PR DESCRIPTION
### What does this PR do?
`windows-latest` was [recently switched to `windows-2025`](https://github.com/actions/runner-images/issues/12677), which quite unfortunately [doesn't come with NSIS pre-installed](https://github.com/actions/runner-images/issues/11754). This [breaks our Windows build pipelines](https://github.com/ZenPrivacy/zen-desktop/actions/runs/18065693022/job/51408056302).

We can obviously install NSIS manually in various ways, but for now just pinning the version to `windows-2022` (which should be supported for 3 more years) seems to be the simplest solution.

### How did you verify your code works?
CI runs.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
